### PR TITLE
Fix broken GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,13 @@ jobs:
         pip install -r requirements.txt
         python setup.py sdist bdist_wheel
         cd dist
-        echo "::`echo -n ${{ github.token }} | sha256sum | head -c 64`::set-env name=WHEEL::$(ls *.whl)"
+        echo "::set-env name=WHEEL::$(ls *.whl)::`echo -n ${{ github.token }} | sha256sum | head -c 64`"
     - name: Test it
       env:
         WHEEL: ${{ env.WHEEL }}
-      run: echo "wheel $WHEEL"
+      run: |
+        set -uex
+        echo "wheel $WHEEL"
       # create a new draft release (so we only trigger the deployment pipeline after the draft has been published)
 #    - name: Create Release
 #      id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,6 @@ on:
     tags:
     # Push events to matching 'v*', i.e. 'v1.0', 'v20.15.10b5'
     - 'v*'
-  # TODO remove
-  pull_request:
-    branches:
-    - master
 
 jobs:
   release:
@@ -28,37 +24,31 @@ jobs:
         python setup.py sdist bdist_wheel
         cd dist
         echo "WHEEL=`ls *.whl`" >> $GITHUB_ENV
-    - name: Test it
-      env:
-        WHEEL: ${{ env.WHEEL }}
-      run: |
-        set -uex
-        echo "wheel $WHEEL or ${{ env.WHEEL }}"
       # create a new draft release (so we only trigger the deployment pipeline after the draft has been published)
-#    - name: Create Release
-#      id: create_release
-#      uses: actions/create-release@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        tag_name: ${{ github.ref }}
-#        release_name: Release ${{ github.ref }}
-#        draft: true
-#        prerelease: false
-#      # upload the wheel to the draft release
-#    - name: Upload Release Asset
-#      id: upload-release-asset
-#      uses: actions/upload-release-asset@v1.0.2
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        upload_url: ${{ steps.create_release.outputs.upload_url }}
-#        asset_path: ./dist/${{ env.WHEEL }}
-#        asset_name: ${{ env.WHEEL }}
-#        asset_content_type: application/zip
-#      # release on TestPyPI (for release on regular PyPI, see deploy.yml)
-#    - name: Publish Package to TestPyPI
-#      uses: pypa/gh-action-pypi-publish@master
-#      with:
-#        password: ${{ secrets.PYPI_TEST_API_TOKEN }}
-#        repository_url: https://test.pypi.org/legacy/
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: true
+        prerelease: false
+      # upload the wheel to the draft release
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./dist/${{ env.WHEEL }}
+        asset_name: ${{ env.WHEEL }}
+        asset_content_type: application/zip
+      # release on TestPyPI (for release on regular PyPI, see deploy.yml)
+    - name: Publish Package to TestPyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_TEST_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,9 @@ jobs:
         cd dist
         echo "::`echo -n ${{ github.token }} | sha256sum | head -c 64`::set-env name=WHEEL::$(ls *.whl)"
     - name: Test it
-      run: echo "wheel ${{ env.WHEEL }}"
+      env:
+        WHEEL: ${{ env.WHEEL }}
+      run: echo "wheel $WHEEL"
       # create a new draft release (so we only trigger the deployment pipeline after the draft has been published)
 #    - name: Create Release
 #      id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,13 @@ jobs:
         pip install -r requirements.txt
         python setup.py sdist bdist_wheel
         cd dist
-        echo "::set-env name=WHEEL::$(ls *.whl)::`echo -n ${{ github.token }} | sha256sum | head -c 64`"
+        echo "WHEEL=`ls *.whl`" >> $GITHUB_ENV
     - name: Test it
       env:
         WHEEL: ${{ env.WHEEL }}
       run: |
         set -uex
-        echo "wheel $WHEEL"
+        echo "wheel $WHEEL or ${{ env.WHEEL }}"
       # create a new draft release (so we only trigger the deployment pipeline after the draft has been published)
 #    - name: Create Release
 #      id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,7 @@ jobs:
         pip install -r requirements.txt
         python setup.py sdist bdist_wheel
         cd dist
-        echo "::`echo -n ${{ github.token }} | sha256sum | head -c 64`::"
-        echo "::set-env name=WHEEL::$(ls *.whl)"
+        echo "::`echo -n ${{ github.token }} | sha256sum | head -c 64`::set-env name=WHEEL::$(ls *.whl)"
     - name: Test it
       run: echo "wheel ${{ env.WHEEL }}"
       # create a new draft release (so we only trigger the deployment pipeline after the draft has been published)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
     # Push events to matching 'v*', i.e. 'v1.0', 'v20.15.10b5'
     - 'v*'
+  # TODO remove
+  pull_request:
+    branches:
+    - master
 
 jobs:
   release:
@@ -23,32 +27,35 @@ jobs:
         pip install -r requirements.txt
         python setup.py sdist bdist_wheel
         cd dist
+        echo "::`echo -n ${{ github.token }} | sha256sum | head -c 64`::"
         echo "::set-env name=WHEEL::$(ls *.whl)"
+    - name: Test it
+      run: echo "wheel ${{ env.WHEEL }}"
       # create a new draft release (so we only trigger the deployment pipeline after the draft has been published)
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: true
-        prerelease: false
-      # upload the wheel to the draft release
-    - name: Upload Release Asset
-      id: upload-release-asset
-      uses: actions/upload-release-asset@v1.0.2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./dist/${{ env.WHEEL }}
-        asset_name: ${{ env.WHEEL }}
-        asset_content_type: application/zip
-      # release on TestPyPI (for release on regular PyPI, see deploy.yml)
-    - name: Publish Package to TestPyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.PYPI_TEST_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+#    - name: Create Release
+#      id: create_release
+#      uses: actions/create-release@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        tag_name: ${{ github.ref }}
+#        release_name: Release ${{ github.ref }}
+#        draft: true
+#        prerelease: false
+#      # upload the wheel to the draft release
+#    - name: Upload Release Asset
+#      id: upload-release-asset
+#      uses: actions/upload-release-asset@v1.0.2
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        upload_url: ${{ steps.create_release.outputs.upload_url }}
+#        asset_path: ./dist/${{ env.WHEEL }}
+#        asset_name: ${{ env.WHEEL }}
+#        asset_content_type: application/zip
+#      # release on TestPyPI (for release on regular PyPI, see deploy.yml)
+#    - name: Publish Package to TestPyPI
+#      uses: pypa/gh-action-pypi-publish@master
+#      with:
+#        password: ${{ secrets.PYPI_TEST_API_TOKEN }}
+#        repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
due to a [security vulnerability in GitHub Actions](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/), the use of `set-env` was deactivated. We need to work around this.

we should switch to [environment files](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#environment-files) instead.