### PR TITLE
Fix AttributeError on empty object fields in to_dict()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/at-gmbh/personio-py/compare/v0.2.3...HEAD)
 
-* drop support for Python 3.7-3.9 (all end-of-life); personio-py now requires Python >= 3.10 ([#39](https://github.com/at-gmbh/personio-py/pull/46)
-* raise the `requests` requirement to a modern version (`requests~=2.32`) ([#39](https://github.com/at-gmbh/personio-py/pull/46)
+* drop support for Python 3.7-3.9 (all end-of-life); personio-py now requires Python >= 3.10 ([#46](https://github.com/at-gmbh/personio-py/pull/46)
+* raise the `requests` requirement to a modern version (`requests~=2.32`) ([#46](https://github.com/at-gmbh/personio-py/pull/46)
 * modernize the development tooling: replace flake8 with ruff, add pip-audit and bandit to
-  pre-commit, bump all pre-commit hooks, and migrate the Sphinx docs to myst-parser ([#39](https://github.com/at-gmbh/personio-py/pull/46)
+  pre-commit, bump all pre-commit hooks, and migrate the Sphinx docs to myst-parser ([#46](https://github.com/at-gmbh/personio-py/pull/46)
 * send auth credentials in the request body instead of the query string, as required by
   the Personio API security update effective 2025-12-01 (query-string credentials return
   a 403 Forbidden from that date on) ([#45](https://github.com/at-gmbh/personio-py/pull/45)
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   those requests, consistent with the existing image endpoints)
 * fix `AttributeError` in `to_dict()` when an object field is returned
   empty (`""` or `[]`) instead of `null` by the Personio API; such empty object fields are now
-  deserialized to `None`
+  deserialized to `None` ([#47](https://github.com/at-gmbh/personio-py/pull/47)
 * add support for providing a custom `requests.Session` in client
   ([#39](https://github.com/at-gmbh/personio-py/pull/39)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * fix `PersonioError: Missing Authorization Header in response` for the attendances and
   projects endpoints, which do not return a rotating auth token (disable auth rotation for
   those requests, consistent with the existing image endpoints)
+* fix `AttributeError` in `to_dict()` when an object field is returned
+  empty (`""` or `[]`) instead of `null` by the Personio API; such empty object fields are now
+  deserialized to `None`
 * add support for providing a custom `requests.Session` in client
   ([#39](https://github.com/at-gmbh/personio-py/pull/39)
 

--- a/src/personio_py/models.py
+++ b/src/personio_py/models.py
@@ -152,6 +152,9 @@ class PersonioResource:
                 field_mapping = field_mapping_dict[key]
                 if not cls._is_empty(value):
                     value = field_mapping.deserialize(value, client=client)
+                elif isinstance(field_mapping, ObjectFieldMapping):
+                    # empty object fields ("" or []) are not valid objects -> None
+                    value = None
                 kwargs[field_mapping.class_field] = value
             else:
                 log_once(logging.WARNING, f"unexpected field '{key}' in class {cls.__name__}")
@@ -335,6 +338,9 @@ class LabeledAttributesMixin(PersonioResource):
                 value = data['value']
                 if not cls._is_empty(value):
                     value = field_mapping.deserialize(value, client=client)
+                elif isinstance(field_mapping, ObjectFieldMapping):
+                    # empty object fields ("" or []) are not valid objects -> None
+                    value = None
                 kwargs[field_mapping.class_field] = value
             elif key.startswith('dynamic_'):
                 dyn = DynamicAttr.from_dict(key, data)

--- a/tests/test_absence.py
+++ b/tests/test_absence.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from datetime import date
 
 from personio_py import Absence
@@ -46,3 +47,16 @@ def test_serialize_absence():
     absence = Absence.from_dict(absence_dict)
     d = absence.to_dict()
     assert d == absence_dict
+
+
+def test_empty_object_field_deserializes_to_none():
+    # Personio may return "" or [] (instead of null) for an empty object field. Such empty values
+    # must become None, otherwise to_dict() crashes when serializing the raw str/list as an object.
+    # Absence uses PersonioResource._map_fields (unlike Employee's LabeledAttributesMixin path).
+    for empty_value in ('', []):
+        d = deepcopy(absence_dict)
+        d['attributes']['certificate'] = empty_value
+        absence = Absence.from_dict(d)
+        assert absence.certificate is None
+        serialized = absence.to_dict()
+        assert 'certificate' not in serialized['attributes']

--- a/tests/test_employee.py
+++ b/tests/test_employee.py
@@ -122,6 +122,20 @@ def test_resource_ordering():
     assert employee_2 < employee_1
 
 
+def test_empty_object_field_deserializes_to_none():
+    # Personio sometimes returns "" or [] (instead of null) for an empty object field such as
+    # work_schedule. Such empty values must become None, otherwise to_dict() crashes when it tries
+    # to serialize the raw str/list as if it were a WorkSchedule object.
+    for empty_value in ('', []):
+        d = deepcopy(employee_dict)
+        d['attributes']['work_schedule'] = {'label': 'Work schedule', 'value': empty_value}
+        employee = Employee.from_dict(d)
+        assert employee.work_schedule is None
+        # to_dict() must not raise and must omit the empty work_schedule field
+        serialized = employee.to_dict()
+        assert 'work_schedule' not in serialized['attributes']
+
+
 def get_employee_dict_mod(**overrides):
     employee_dict_mod = deepcopy(employee_dict)
     attrs = employee_dict_mod['attributes']


### PR DESCRIPTION
Fix AttributeError on empty object fields in to_dict()

The Personio API sometimes returns an empty value ("" or []) instead of
null for scalar object fields such as work_schedule. _map_fields kept the
raw empty value (a str/list) because the _is_empty short-circuit skipped
deserialization. to_dict() then called ObjectFieldMapping.serialize, which
invokes value.to_dict() on the str/list and raised AttributeError.

Empty scalar object fields are now deserialized to None, consistent with
all other empty object fields. Scalar (FieldMapping) and list
(ListFieldMapping) fields are unchanged.

- fix in both PersonioResource._map_fields and LabeledAttributesMixin._map_fields
- add regression test for "" and [] work_schedule values
- update example.py to verify work_schedule handling against a live instance

## Checklist for your PR

- [x] please start with a draft PR and mark it as *ready for review* when you are confident that your implementation works as expected.
- [x] add a changelog entry in [CHANGELOG.md](https://github.com/at-gmbh/personio-py/blob/master/CHANGELOG.md) with a link to this PR.
- [x] make sure that all tests pass and add new test functions if your code is not covered by existing tests. Please use mock tests when network requests are required.
- [ ] let someone review & approve your code, make changes where necessary.

## Hints

* name your branches accordingly: use the prefixes `bugfix/`, `feature/`, or `release/` and then a short title for your PR in kebab-case (lowercase words separated with dashes), e.g. `feature/my-awesome-feature`.
* Please make sure that [pre-commit hooks](https://github.com/at-gmbh/personio-py#contributing) are enabled on your system to avoid common mistakes before you make a commit.
* feel free to delete this template and replace it with your own description of the PR.
